### PR TITLE
Small updates for simple-auth >1.0 and latest version(s) of ember

### DIFF
--- a/app/authenticators/parse-token.js
+++ b/app/authenticators/parse-token.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import BaseAuthenticator from 'simple-auth/authenticators/base';
+import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 
 export default BaseAuthenticator.extend({
   restore: function(data) {

--- a/app/authenticators/parse-token.js
+++ b/app/authenticators/parse-token.js
@@ -6,7 +6,8 @@ export default BaseAuthenticator.extend({
     data = data || {};
 
     if(data.sessionToken) {
-      var adapter = this.container.lookup('store:main').adapterFor('parseUser');
+      var store = this.container.lookup('service:store') || this.container.lookup('store:main');
+      var adapter = store.adapterFor('parseUser');
 
       return adapter.ajax('https://api.parse.com/1/users/me', 'GET', {
         headers: {
@@ -23,7 +24,8 @@ export default BaseAuthenticator.extend({
   authenticate: function(data) {
     data = data || {};
 
-    var adapter = this.container.lookup('store:main').adapterFor('parseUser');
+    var store = this.container.lookup('service:store') || this.container.lookup('store:main');
+    var adapter = store.adapterFor('parseUser');
 
     return adapter.ajax('https://api.parse.com/1/users/me', 'GET', {
       headers: {

--- a/app/authenticators/parse-username.js
+++ b/app/authenticators/parse-username.js
@@ -6,7 +6,8 @@ export default BaseAuthenticator.extend({
     data = data || {};
 
     if(data.sessionToken) {
-      var adapter = this.container.lookup('store:main').adapterFor('parseUser');
+      var store = this.container.lookup('service:store') || this.container.lookup('store:main');
+      var adapter = store.adapterFor('parseUser');
 
       return adapter.ajax('https://api.parse.com/1/users/me', 'GET', {
         headers: {
@@ -23,7 +24,8 @@ export default BaseAuthenticator.extend({
   authenticate: function(data) {
     data = data || {};
 
-    var adapter = this.container.lookup('store:main').adapterFor('parseUser');
+    var store = this.container.lookup('service:store') || this.container.lookup('store:main');
+    var adapter = store.adapterFor('parseUser');
 
     return adapter.ajax('https://api.parse.com/1/login', 'GET', {
       data: {

--- a/app/authenticators/parse-username.js
+++ b/app/authenticators/parse-username.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import BaseAuthenticator from 'simple-auth/authenticators/base';
+import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 
 export default BaseAuthenticator.extend({
   restore: function(data) {

--- a/app/authorizers/parse.js
+++ b/app/authorizers/parse.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import BaseAuthorizer from 'simple-auth/authorizers/base';
+import BaseAuthorizer from 'ember-simple-auth/authorizers/base';
 
 export default BaseAuthorizer.extend({
   authorize: function(jqXHR) {

--- a/app/initializers/parse-current-user.js
+++ b/app/initializers/parse-current-user.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import Session from 'simple-auth/session';
+import Session from 'ember-simple-auth/services/session';
 
 export default {
   name: 'parse-current-user',
-  before: 'simple-auth',
+  before: 'ember-simple-auth',
   initialize: function(container) {
     Session.reopen({
       currentUser: function() {

--- a/app/initializers/parse-current-user.js
+++ b/app/initializers/parse-current-user.js
@@ -4,21 +4,20 @@ import Session from 'ember-simple-auth/services/session';
 export default {
   name: 'parse-current-user',
   before: 'ember-simple-auth',
-  initialize: function(container) {
+  initialize: function() {
     Session.reopen({
       currentUser: function() {
 
-        var userData = this.get('secure.userData');
+        var userData = this.get('data.secure.userData');
 
         if(Ember.isEmpty(userData)) {
           return null;
         } else {
-          var store = container.lookup('store:main');
+          var store = this.container.lookup('service:store') || this.container.lookup('store:main');
           var model = store.modelFor('parseUser');
-          var serializer = store.serializerFor(model);
-          serializer.normalize(model, userData);
-          var record = store.push(model, userData);
-          return record;
+          var serializer = store.serializerFor(model.modelName);
+          var data = serializer.normalize(model, userData);
+          return store.push(data);
         }
       }.property('secure.userData')
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-simple-auth-parse",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "ember-simple-auth integration for Parse",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Using this library for a project and noticed several issues when upgrading the Ember 2.0 and Simple Auth 1.0 (which is a necessary upgrade to use Ember 2.0). Tried to make the changes so that they do not break for those still on Ember versions lower than 2.0. This change will require a bump to Simple Auth, though, due to a change they made to their file paths (simple-auth -> ember-simple-auth). However, developers can upgrade to the latest version of Simple Auth without being required to upgrade Ember.
